### PR TITLE
#163511591 consume signup

### DIFF
--- a/UI/css/signup.css
+++ b/UI/css/signup.css
@@ -202,6 +202,17 @@ span {
   color: #00bfff;
 }
 
+.signin-message {
+  background: #ffffff;
+  color: #00bfff;
+}
+
+#red {
+  font-size:12px;
+  font-weight: bolder;
+  color:red;
+}
+
 a {
   position: absolute;
   width: 150px;

--- a/UI/scripts/fetchsignup.js
+++ b/UI/scripts/fetchsignup.js
@@ -1,5 +1,7 @@
-const baseUrl = 'https://drizzyquestioner.herokuapp.com/api/v1';
-const localUrl = 'http://localhost:3000/api/v1';
+const windowUrlArray = window.location.href.split('/');
+windowUrlArray.pop();
+const windowUrl = windowUrlArray.join('/');
+const apiUrl = 'https://drizzyquestioner.herokuapp.com/api/v1';
 const firstnameInput = document.querySelector('#firstname');
 const lastnameInput = document.querySelector('#lastname');
 const emailInput = document.querySelector('#email');
@@ -26,7 +28,7 @@ const inputErrorHandler = (errorArray, errorData) => {
     const checkFieldError = inputFields.find(field => field.id === errorId);
     removeClass(`.${errorId}`);
     checkFieldError.insertAdjacentHTML('afterend', `
-    <p class="${errorId}">${errorData[errorId][0]}</p><br>
+    <p class="${errorId}" id="red">${errorData[errorId][0]}</p><br>
     `);
   });
 };
@@ -34,14 +36,14 @@ const inputErrorHandler = (errorArray, errorData) => {
 const emailErrorHandler = (errorData) => {
   removeClass('.emailerror');
   emailInput.insertAdjacentHTML('afterend', `
-  <p class="emailerror">${errorData}</p><br>
+  <p class="emailerror" id="red">${errorData}</p><br>
   `);
 };
 
 const usernameErrorHandler = (errorData) => {
   removeClass('.usernameerror');
   usernameInput.insertAdjacentHTML('afterend', `
-  <p class="usernameerror">${errorData}</p><br>
+  <p class="usernameerror" id="red">${errorData}</p><br>
   `);
 };
 
@@ -62,7 +64,7 @@ const fetchSignup = async (e) => {
     firstname, lastname, username, email, password, password_confirmation: passwordConf, phonenumber,
   };
 
-  await fetch(`${localUrl}/auth/signup`, {
+  await fetch(`${apiUrl}/auth/signup`, {
     method: 'POST',
     mode: 'cors',
     body: JSON.stringify(userObject),
@@ -72,6 +74,7 @@ const fetchSignup = async (e) => {
     .then((data) => {
       submitBtn.value = 'Signup';
       submitBtn.disabled = false;
+      console.log(windowUrl);
 
       if (data.error) {
         if (data.status === 400) {
@@ -85,6 +88,19 @@ const fetchSignup = async (e) => {
           return usernameErrorHandler(errorData);
         }
       }
+      if (data.status === 201) {
+        submitBtn.disabled = false;
+        const wrapper = document.getElementById('wrapper');
+        wrapper.insertAdjacentHTML('afterbegin', `
+        <div class="signin-message">
+        <p> You have successfully signed up. You will be redirected to the login page.</p>
+        </div>
+        `);
+        setTimeout(() => {
+          window.location.href = `${windowUrl}/signin.html`;
+        }, 5000);
+      }
+      return true;
     })
     .catch(err => console.log(err));
 };

--- a/UI/scripts/fetchsignup.js
+++ b/UI/scripts/fetchsignup.js
@@ -1,0 +1,93 @@
+const baseUrl = 'https://drizzyquestioner.herokuapp.com/api/v1';
+const localUrl = 'http://localhost:3000/api/v1';
+const firstnameInput = document.querySelector('#firstname');
+const lastnameInput = document.querySelector('#lastname');
+const emailInput = document.querySelector('#email');
+const passwordInput = document.querySelector('#password');
+const passwordConfInput = document.querySelector('#password_confirmation');
+const usernameInput = document.querySelector('#username');
+const phonenumberInput = document.querySelector('#phonenumber');
+const inputFields = [
+  firstnameInput, lastnameInput, emailInput, passwordInput,
+  passwordConfInput, usernameInput, phonenumberInput,
+];
+
+const removeClass = (errorclass) => {
+  const errorText = document.querySelector(errorclass);
+  if (errorText) {
+    errorText.display.hidden = true;
+    errorText.remove();
+  }
+};
+
+const inputErrorHandler = (errorArray, errorData) => {
+  errorArray.forEach((errorKey) => {
+    const errorId = `${errorKey}`;
+    const checkFieldError = inputFields.find(field => field.id === errorId);
+    removeClass(`.${errorId}`);
+    checkFieldError.insertAdjacentHTML('afterend', `
+    <p class="${errorId}">${errorData[errorId][0]}</p><br>
+    `);
+  });
+};
+
+const emailErrorHandler = (errorData) => {
+  removeClass('.emailerror');
+  emailInput.insertAdjacentHTML('afterend', `
+  <p class="emailerror">${errorData}</p><br>
+  `);
+};
+
+const usernameErrorHandler = (errorData) => {
+  removeClass('.usernameerror');
+  usernameInput.insertAdjacentHTML('afterend', `
+  <p class="usernameerror">${errorData}</p><br>
+  `);
+};
+
+const fetchSignup = async (e) => {
+  e.preventDefault();
+  const firstname = firstnameInput.value;
+  const lastname = lastnameInput.value;
+  const email = emailInput.value;
+  const password = passwordInput.value;
+  const passwordConf = passwordConfInput.value;
+  const username = usernameInput.value;
+  const phonenumber = phonenumberInput.value;
+  const submitBtn = document.querySelector('#submit');
+
+  submitBtn.value = 'Signing up...';
+  submitBtn.disabled = true;
+  const userObject = {
+    firstname, lastname, username, email, password, password_confirmation: passwordConf, phonenumber,
+  };
+
+  await fetch(`${localUrl}/auth/signup`, {
+    method: 'POST',
+    mode: 'cors',
+    body: JSON.stringify(userObject),
+    headers: { 'Content-Type': 'application/json' },
+  })
+    .then(res => res.json())
+    .then((data) => {
+      submitBtn.value = 'Signup';
+      submitBtn.disabled = false;
+
+      if (data.error) {
+        if (data.status === 400) {
+          const errorData = data.error;
+          const errorArray = Object.keys(data.error);
+          return inputErrorHandler(errorArray, errorData);
+        }
+        if (data.status === 409) {
+          const errorData = data.error;
+          if (errorData.includes('email')) return emailErrorHandler(errorData);
+          return usernameErrorHandler(errorData);
+        }
+      }
+    })
+    .catch(err => console.log(err));
+};
+
+const signupForm = document.querySelector('#signup_form');
+signupForm.addEventListener('submit', fetchSignup);

--- a/UI/signup.html
+++ b/UI/signup.html
@@ -16,34 +16,34 @@
       </header>
     </div>
     <div id="wrapper">
-        <form action="userhome.html">
+        <form id="signup_form">
             <fieldset>
                 <legend>Signup Form</legend>
                 <div>
-                    <input type="text" name="first_name" placeholder="First Name" maxlength="24" required />
+                    <input type="text" id="firstname" placeholder="First Name" maxlength="24" required />
                 </div>
                 <div>
-                    <input type="text" name="last_name" placeholder="Last Name" maxlength="24" required />
+                    <input type="text" id="lastname" placeholder="Last Name" maxlength="24" required />
                 </div>
                 <div>
-                    <input type="email" name="email" placeholder="Email" required />
+                    <input type="email" id="email" placeholder="Email" required />
                 </div>
                 <div>
-                    <input type="password" name="password" placeholder="Password" maxlength="18" required />
+                    <input type="password" id="password" placeholder="Password" maxlength="18" required />
                 </div>
                 <div class="small">
                   Your password should be between six and 18 characters long.
                 </div>
                 <div>
-                    <input type="password" name="conf_password" placeholder="Confirm Password" maxlength="18" required />
+                    <input type="password" id="password_confirmation" placeholder="Confirm Password" maxlength="18" required />
                 </div>
                 <div>
-                    <input type="text" name="user_name" placeholder="Username" maxlength="24" required />
+                    <input type="text" id="username" placeholder="Username" maxlength="24" required />
                 </div>
                 <div>
-                    <input type="tel" name="phone" placeholder="Phone Number" maxlength="24" required />
+                    <input type="tel" id="phonenumber" placeholder="Phone Number" maxlength="24" required />
                 </div>
-                <input type="submit" name="submit" value="Signup"/>
+                <input type="submit" id="submit" value="Signup"/>
             </fieldset>
         </form>
     </div>
@@ -53,5 +53,7 @@
           <div class="footer">
           </div>
       </footer>
+      <script type="text/javascript" src="scripts/fetchsignup.js">
+      </script>
   </body>
 </html>

--- a/api/app.js
+++ b/api/app.js
@@ -1,9 +1,11 @@
 import express from 'express';
+import cors from 'cors';
 
 import routes from './v1/routes';
 
 const app = express();
 
+app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use('/api/v1', routes);

--- a/api/v1/controllers/questionscontroller.js
+++ b/api/v1/controllers/questionscontroller.js
@@ -54,7 +54,14 @@ export default class QuestionsController {
 
     const voted = await Question.ifVoted(userid, questionid);
     if (voted) {
-      return errorResponse(res, 400, `You have already ${voted.vote} this question`);
+      if (voted.vote === 'downvoted') {
+        const upvoteErrorMessage = 'You have downvoted this question. Click on the'
+        + ' downvote button again to remove your downvote.';
+        return errorResponse(res, 400, upvoteErrorMessage);
+      }
+      await Question.changeVotesTable(userid, questionid);
+      const changeVote = await Question.changeUpvoteQuestion(questionid);
+      return successResponse(res, 200, 'You have removed your upvote.', changeVote);
     }
 
     const vote = 'upvoted';
@@ -83,7 +90,14 @@ export default class QuestionsController {
 
     const voted = await Question.ifVoted(userid, questionid);
     if (voted) {
-      return errorResponse(res, 400, `You have already ${voted.vote} this question`);
+      if (voted.vote === 'upvoted') {
+        const downvoteErrorMessage = 'You have upvoted this question. Click on the'
+        + ' upvote button again to remove your upvote.';
+        return errorResponse(res, 400, downvoteErrorMessage);
+      }
+      await Question.changeVotesTable(userid, questionid);
+      const changeVote = await Question.changeDownvoteQuestion(questionid);
+      return successResponse(res, 200, 'You have removed your downvote.', changeVote);
     }
 
     const vote = 'downvoted';

--- a/api/v1/controllers/userscontroller.js
+++ b/api/v1/controllers/userscontroller.js
@@ -107,14 +107,15 @@ export default class UsersController {
     const commented = await Comment.getMyCommentedQuestions(id);
     const allComments = await Comment.getMyComments(id);
 
-    const finalResult = {};
-    finalResult.firstname = detailsResult.firstname;
-    finalResult.lastname = detailsResult.lastname;
-    finalResult.username = detailsResult.username;
-    finalResult.joinedMeetups = joinedMeetups.length || 0;
-    finalResult.questionsPosted = questionsPosted.length || 0;
-    finalResult.commentedOn = commented.length || 0;
-    finalResult.allComments = allComments.length || 0;
+    const finalResult = {
+      firstname: detailsResult.firstname,
+      lastname: detailsResult.lastname,
+      username: detailsResult.username,
+      joinedMeetups: joinedMeetups.length || 0,
+      questionsPosted: questionsPosted.length || 0,
+      commentedOn: commented.length || 0,
+      allComments: allComments.length || 0,
+    };
 
     return successResponse(res, 200, 'Profile Details found', [finalResult]);
   }

--- a/api/v1/controllers/userscontroller.js
+++ b/api/v1/controllers/userscontroller.js
@@ -55,7 +55,7 @@ export default class UsersController {
 
     const { id, username, isadmin } = result;
     const token = await Jwt.generateToken({ id, username, isadmin });
-    return successResponse(res, 200, 'You are logged in.', token);
+    return successResponse(res, 200, 'You are logged in.', [{ token, isadmin }]);
   }
 
   /**

--- a/api/v1/models/Questions.js
+++ b/api/v1/models/Questions.js
@@ -30,8 +30,22 @@ export default class Question {
     return rows[0];
   }
 
+  static async changeUpvoteQuestion(id) {
+    const queryString = 'UPDATE questions SET upvotes = upvotes - 1 WHERE id = $1 RETURNING *';
+    const values = [id];
+    const { rows } = await pool.query(queryString, values);
+    return rows[0];
+  }
+
   static async downvoteQuestion(id) {
     const queryString = 'UPDATE questions SET downvotes = downvotes + 1 WHERE id = $1 RETURNING *';
+    const values = [id];
+    const { rows } = await pool.query(queryString, values);
+    return rows[0];
+  }
+
+  static async changeDownvoteQuestion(id) {
+    const queryString = 'UPDATE questions SET downvotes = downvotes - 1 WHERE id = $1 RETURNING *';
     const values = [id];
     const { rows } = await pool.query(queryString, values);
     return rows[0];
@@ -41,6 +55,13 @@ export default class Question {
     const queryString = `INSERT INTO votes (userid, questionid, vote) VALUES
     ($1, $2, $3)`;
     const values = [userid, questionid, vote];
+    const result = await pool.query(queryString, values);
+    return result;
+  }
+
+  static async changeVotesTable(userid, questionid) {
+    const queryString = 'DELETE FROM votes WHERE userid = $1 AND questionid = $2';
+    const values = [userid, questionid];
     const result = await pool.query(queryString, values);
     return result;
   }

--- a/api/v1/models/Users.js
+++ b/api/v1/models/Users.js
@@ -13,7 +13,8 @@ export default class User {
   async signUp() {
     const queryString = `INSERT INTO users (firstname, lastname,
       username, email, password,  phonenumber)
-      VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`;
+      VALUES ($1, $2, $3, $4, $5, $6) RETURNING firstname, lastname,
+        username, email, phonenumber`;
     const values = [this.firstname, this.lastname, this.username,
       this.email, this.password, this.phonenumber];
     const { rows } = await pool.query(queryString, values);
@@ -53,7 +54,8 @@ export default class User {
       firstname, lastname, username, email, password, phonenumber,
     } = user;
     const queryString = `UPDATE users SET firstname = $1, lastname = $2, username = $3,
-     email = $4, password = $5, phonenumber =$6 WHERE id = $7 RETURNING *`;
+     email = $4, password = $5, phonenumber =$6 WHERE id = $7 RETURNING firstname, lastname,
+       username, email, phonenumber`;
     const values = [firstname, lastname, username, email, password, phonenumber, id];
     const { rows } = await pool.query(queryString, values);
     return rows[0];

--- a/api/v1/tests/controllers/comments.test.js
+++ b/api/v1/tests/controllers/comments.test.js
@@ -14,7 +14,7 @@ describe('Comments', () => {
       .post('/api/v1/auth/login')
       .send(userLogin);
 
-    userToken = userResponse.body.data;
+    userToken = userResponse.body.data[0].token;
   });
 
   describe('GET /:id', () => {

--- a/api/v1/tests/controllers/meetups.test.js
+++ b/api/v1/tests/controllers/meetups.test.js
@@ -19,14 +19,14 @@ describe('Meetups', () => {
       .post('/api/v1/auth/login')
       .send(correctLogin);
 
-    adminToken = response.body.data;
+    adminToken = response.body.data[0].token;
 
     const userResponse = await chai
       .request(app)
       .post('/api/v1/auth/login')
       .send(userLogin);
 
-    userToken = userResponse.body.data;
+    userToken = userResponse.body.data[0].token;
   });
   describe('GET /', () => {
     it('should return an empty array if no meetups exist', async () => {

--- a/api/v1/tests/controllers/questions.test.js
+++ b/api/v1/tests/controllers/questions.test.js
@@ -121,13 +121,22 @@ describe('Questions', () => {
       expect(res.body).to.have.property('data');
     });
 
-    it('it should return 400 if user tries to vote twice', async () => {
+    it('it should return 400 if user downvotes after upvoting', async () => {
+      const res = await chai.request(app)
+        .patch('/api/v1/questions/1/downvote')
+        .set({ Authorization: `Bearer ${adminToken}` });
+
+      expect(res).to.have.status(400);
+      expect(res.body).to.have.property('error');
+    });
+
+    it('it should return 200 if user removes upvote', async () => {
       const res = await chai.request(app)
         .patch('/api/v1/questions/1/upvote')
         .set({ Authorization: `Bearer ${adminToken}` });
 
-      expect(res).to.have.status(400);
-      expect(res.body.error).to.equal('You have already upvoted this question');
+      expect(res).to.have.status(200);
+      expect(res.body).to.have.property('data');
     });
   });
 
@@ -150,13 +159,22 @@ describe('Questions', () => {
       expect(res.body).to.have.property('data');
     });
 
-    it('it should return 400 if user tries to vote twice', async () => {
+    it('it should return 400 if user upvotes after downvoting', async () => {
       const res = await chai.request(app)
-        .patch('/api/v1/questions/2/downvote')
-        .set({ Authorization: `Bearer ${userToken}` });
+        .patch('/api/v1/questions/2/upvote')
+        .set({ Authorization: `Bearer ${adminToken}` });
 
       expect(res).to.have.status(400);
-      expect(res.body.error).to.equal('You have already downvoted this question');
+      expect(res.body).to.have.property('error');
+    });
+
+    it('it should return 200 if user removes downvote', async () => {
+      const res = await chai.request(app)
+        .patch('/api/v1/questions/1/upvote')
+        .set({ Authorization: `Bearer ${adminToken}` });
+
+      expect(res).to.have.status(200);
+      expect(res.body).to.have.property('data');
     });
   });
 });

--- a/api/v1/tests/controllers/questions.test.js
+++ b/api/v1/tests/controllers/questions.test.js
@@ -18,14 +18,14 @@ describe('Questions', () => {
       .post('/api/v1/auth/login')
       .send(correctLogin);
 
-    adminToken = response.body.data;
+    adminToken = response.body.data[0].token;
 
     const userResponse = await chai
       .request(app)
       .post('/api/v1/auth/login')
       .send(userLogin);
 
-    userToken = userResponse.body.data;
+    userToken = userResponse.body.data[0].token;
   });
 
   describe('PATCH /:id/upvote', () => {

--- a/api/v1/tests/controllers/rsvp.test.js
+++ b/api/v1/tests/controllers/rsvp.test.js
@@ -14,14 +14,14 @@ describe('Rsvps', () => {
       .post('/api/v1/auth/login')
       .send(correctLogin);
 
-    adminToken = response.body.data;
+    adminToken = response.body.data[0].token;
 
     const userResponse = await chai
       .request(app)
       .post('/api/v1/auth/login')
       .send(userLogin);
 
-    userToken = userResponse.body.data;
+    userToken = userResponse.body.data[0].token;
   });
 
   describe('GET /rsvps', () => {

--- a/api/v1/tests/controllers/users.test.js
+++ b/api/v1/tests/controllers/users.test.js
@@ -19,14 +19,14 @@ describe('Users', () => {
       .post('/api/v1/auth/login')
       .send(correctLogin);
 
-    adminToken = response.body.data;
+    adminToken = response.body.data[0].token;
 
     const userResponse = await chai
       .request(app)
       .post('/api/v1/auth/login')
       .send(userLogin);
 
-    userToken = userResponse.body.data;
+    userToken = userResponse.body.data[0].token;
   });
   describe('PUT /', () => {
     it('should return 401 if no token is received', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1443,6 +1443,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "coveralls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "express": "^4.16.4",
     "jsonwebtoken": "^8.4.0",


### PR DESCRIPTION
## What does this PR do?
Adds consume signup endpoint functionality to the application

## Description of Task to be completed
- Consume `POST api/v1/auth/signup` endpoint
- Minor changes to the UI

## How should this be manually tested?
- Clone the repo
- Checkout to the branch `ft-fetchsignup-163511591`
- Install Postgresql from [here](https://www.postgresql.org/)
- Create a database called questionertest
- Run `npm instal`l to install application dependencies
- Run `npm run pretest` to seed database with required data
- Run `npm run devstart` to start the development server
- change the apiUrl in the UI/fetchscripts/fetchsignup directory to `http://localhost:3000/api/v1`
- Navigate to UI/signup.html

## What are the relevant pivotal tracker stories?
[163511591](https://www.pivotaltracker.com/n/projects/2232521/stories/163511591)